### PR TITLE
Bugfix_Issue39: Field Validation on Creation Dialogs

### DIFF
--- a/Integra/app/src/main/java/com/dhbw/cas/integra/ui/areas/AreasFragment.kt
+++ b/Integra/app/src/main/java/com/dhbw/cas/integra/ui/areas/AreasFragment.kt
@@ -54,11 +54,38 @@ class AreasFragment : Fragment(), CreateAreaDialogFragment.CreateAreaDialogListe
         fab.setOnClickListener { buttonView ->
             if (areasAdapter.getAreas().size == 10) { // limit number of areas to 10
                 Snackbar.make(buttonView, R.string.max_num_areas, Snackbar.LENGTH_LONG).show()
-            } else { // create and open dialog to create area
-                val dialogFrag = CreateAreaDialogFragment()
+            } else {
+                // create and open dialog to create area WITHOUT FRAGMENT
+                val builder = AlertDialog.Builder(view.context)
+                builder.apply {
+                    setTitle(R.string.new_area)
+                    setView(R.layout.dialog_new_area)
+                    setPositiveButton(R.string.okay, null)
+                    setNegativeButton(R.string.cancel, null)
+                }
+                val dialog = builder.create()
+                dialog.show()
+                //check and create area when dialog is left via "OK"
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                    val correct = validateArea(dialog.new_area_text)
+                    if (correct) {
+                        createArea(
+                            dialog.new_area_text.text.toString(),
+                            dialog.new_area_label_spinner.selectedItem as Int
+                        )
+                        dialog.dismiss()
+                    }
+                }
+                // set adapter for label spinner containing only color labels left
+                val spinnerAdapter =
+                    AreaLabelSpinnerAdapter(view.context, areasAdapter.getLabelArray())
+                dialog.new_area_label_spinner.adapter = spinnerAdapter
+
+                // create and open dialog to create area WITH FRAGMENT
+                /*val dialogFrag = CreateAreaDialogFragment()
                 dialogFrag.setLabelArray(areasAdapter.getLabelArray())
                 dialogFrag.setTargetFragment(this, 1)
-                dialogFrag.show(parentFragmentManager, "CreateAreaDialogFragment")
+                dialogFrag.show(parentFragmentManager, "CreateAreaDialogFragment")*/
             }
         }
         return view

--- a/Integra/app/src/main/java/com/dhbw/cas/integra/ui/catalogue/CatalogueFragment.kt
+++ b/Integra/app/src/main/java/com/dhbw/cas/integra/ui/catalogue/CatalogueFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -53,8 +54,32 @@ class CatalogueFragment : Fragment(), CreateTaskDialogFragment.CreateTaskDialogL
         // add Listener to Add Button
         val fab: FloatingActionButton = binding.actionAddTask
         fab.setOnClickListener {
-            //create and open dialog to create task
-            val dialogFrag = CreateTaskDialogFragment()
+            //create and open dialog to create task WITHOUT FRAGMENT
+            val builder = AlertDialog.Builder(view.context)
+            builder.apply {
+                setTitle(R.string.new_task)
+                setView(R.layout.dialog_new_task)
+                setPositiveButton(R.string.okay, null)
+                setNegativeButton(R.string.cancel, null)
+            }
+            val dialog = builder.create()
+            dialog.show()
+            //check and create task when dialog is left via "OK"
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val correct = validateTask(dialog)
+                if (correct) {
+                    createTask(dialog)
+                    dialog.dismiss()
+                }
+            }
+            // set adapter for areas spinner
+            mainViewModel.getAreaTexts().observe(viewLifecycleOwner, { spinnerData ->
+                val spinnerAdapter = ArrayAdapter(main, android.R.layout.simple_spinner_item, spinnerData)
+                dialog.new_task_area_spinner.adapter = spinnerAdapter
+            })
+
+            //create and open dialog to create task WITH FRAGMENT
+            /*val dialogFrag = CreateTaskDialogFragment()
             dialogFrag.setTargetFragment(this, 1)
             dialogFrag.show(parentFragmentManager, "CreateTaskDialogFragment")
 
@@ -67,7 +92,7 @@ class CatalogueFragment : Fragment(), CreateTaskDialogFragment.CreateTaskDialogL
                         spinnerData
                     )
                 dialogFrag.setSpinnerAdapter(spinnerAdapter)
-            })
+            })*/
         }
 
         return view


### PR DESCRIPTION
For the preference of field validation show creation dialogs without fragment.

Dialog on Fragment dismisses even after fieldvalidation and error state. For now field validation has been considered more important as orientation change so the dialogs are invoked directly again.

closes #39 